### PR TITLE
Remove SSLCertificateChainFile from Apache

### DIFF
--- a/templates/apache
+++ b/templates/apache
@@ -1,4 +1,3 @@
 SSLEngine on
 SSLCertificateKeyFile __KEY_PATH__
 SSLCertificateFile __CERT_PATH__
-SSLCertificateChainFile __CHAIN_PATH__


### PR DESCRIPTION
SSLCertificateChainFile is deprecated
SSLCertificateChainFile became obsolete with version 2.4.8, when SSLCertificateFile was extended to also load intermediate CA certificates from the server certificate file.
https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatechainfile